### PR TITLE
Various Formatting and Configuration Updates

### DIFF
--- a/src/areas/informations.js
+++ b/src/areas/informations.js
@@ -21,7 +21,7 @@ import { h } from "preact"
 import { InformationsControls, QuickButtonsBar } from "../targets"
 const Informations = () => {
     return (
-        <div id="infopage" class="container m-2">
+        <div id="infopage" class="container my-2">
             <InformationsControls />
             <div class="information-buttons-bar m-2">
                 <QuickButtonsBar />

--- a/src/components/ExtraContent/extraContentItem.js
+++ b/src/components/ExtraContent/extraContentItem.js
@@ -223,13 +223,6 @@ const ExtraContentItem = ({
         if (type === "extension" && iframeElement) {
            
             const doc = iframeElement.contentWindow.document
-            // set the height of the iframe as 
-            // the height of the iframe content
-            iframeElement.style.height = iframeElement.contentWindow.document.body.scrollHeight + 'px';
-
-            // set the width of the iframe as the 
-            // width of the iframe content
-            iframeElement.style.width  = iframeElement.contentWindow.document.body.scrollWidth + 'px';
 
             const body = doc.querySelector("body")
             if (!body){

--- a/src/components/ExtraContent/index.js
+++ b/src/components/ExtraContent/index.js
@@ -180,7 +180,7 @@ if (target === "panel") {
     const displayIcon = iconsList[icon] || ""
     return (
         <Fragment>
-            <div class="panel panel-dashboard" id={id}>
+            <div class="panel panel-dashboard panel-extra-content" id={id}>
 
                 <div class="navbar">
                     <span class="navbar-section feather-icon-container">

--- a/src/components/ExtraContent/index.js
+++ b/src/components/ExtraContent/index.js
@@ -82,6 +82,21 @@ const ExtraContent = ({ id, source, refreshtime, label, type, target, icon }) =>
     }, [panels.updateTrigger])
 
     useEffect(() => {
+        if (useUiContextFn.panels.isVisible(id)) {
+            const panelElements = document.querySelectorAll(".panel-dashboard");
+            const resizeObserver = new ResizeObserver((entries) => {
+                entries.forEach((entry) => {
+                    updateContentPosition();
+                });
+            });
+
+            panelElements.forEach((panelElement) => {
+                resizeObserver.observe(panelElement);
+            });
+    }
+    }, [panels.updateTrigger])
+
+    useEffect(() => {
         //console.log("Mount element " + id)
         if (!elementsCache.has(extra_content_id)) {
             console.error("Error display element " + extra_content_id, " because it doesn't exist")

--- a/src/components/Panels/JogCNC.js
+++ b/src/components/Panels/JogCNC.js
@@ -35,7 +35,7 @@ import { showModal } from "../Modal"
 import { useTargetContext, variablesList } from "../../targets"
 
 let currentFeedRate = []
-let currentJogDistance = 100
+let currentJogDistance = "-1"
 let currentAxis = "-1"
 
 const feedList = ["XY", "Z", "A", "B", "C", "U", "V", "W"]
@@ -310,6 +310,10 @@ const JogPanel = () => {
     }
 
     useEffect(() => {
+        if(currentJogDistance == "-1") {
+            currentJogDistance = useUiContextFn.getValue("jogdistancedefault")
+        }
+
         if (currentAxis == "-1") {
             feedList.forEach((letter) => {
                 if (!currentFeedRate[letter]) {

--- a/src/style/components/_app.scss
+++ b/src/style/components/_app.scss
@@ -1,6 +1,6 @@
 html,
 body {
-    height: 100vh;
+    height: 100dvh;
     margin: 0;
     overflow-y: hidden;
     user-select: none;

--- a/src/style/components/_panel.scss
+++ b/src/style/components/_panel.scss
@@ -26,9 +26,11 @@
     display: -ms-flexbox;
     display: flex;
     flex-flow: column;
-    height: 600px;
+    max-height: 600px;
+    height: auto !important;
     overflow-y: auto !important;
     overflow-x: hidden !important;
+    margin: 5px;
 }
 
 .panel {
@@ -49,17 +51,15 @@
     color: #005b96;
 }
 
-
 .panel .panel-body.terminal {
     height: 300px;
     min-height: 300px !important;
 }
 
-.panel:not(.panel-extra-content) {
+.panel-extra-content {
     height: auto !important;
-    max-height: 600px !important;
+    min-height: 550px !important;
 }
-
 
 .panel-item {
     flex: 0 1 auto;

--- a/src/style/components/_panel.scss
+++ b/src/style/components/_panel.scss
@@ -13,15 +13,20 @@
     flex-flow: row wrap;
     justify-content: space-between;
     align-content: stretch;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+.macro-buttons-panel button {
+    flex: 1 1 20% !important;
+    margin: 10px !important;
 }
 
 .panel {
     display: -ms-flexbox;
     display: flex;
     flex-flow: column;
-    height: auto;
-    min-height: 550px;
-    max-height: 650px;
+    height: 600px;
     overflow-y: auto !important;
     overflow-x: hidden !important;
 }
@@ -43,6 +48,18 @@
     background: #f1f1fc;
     color: #005b96;
 }
+
+
+.panel .panel-body.terminal {
+    height: 300px;
+    min-height: 300px !important;
+}
+
+.panel:not(.panel-extra-content) {
+    height: auto !important;
+    max-height: 600px !important;
+}
+
 
 .panel-item {
     flex: 0 1 auto;

--- a/src/tabs/features/index.js
+++ b/src/tabs/features/index.js
@@ -432,7 +432,7 @@ const FeaturesTab = () => {
     //console.log(featuresSettings.current)
     return (
         <div>
-            <div id="features" style="max-height: calc(100vh - 170px); overflow-y: scroll;">
+            <div id="features" style="max-height: calc(100dvh - 170px); overflow-y: scroll;">
                 <input
                     ref={inputFile}
                     type="file"

--- a/src/tabs/interface/index.js
+++ b/src/tabs/interface/index.js
@@ -417,7 +417,7 @@ const InterfaceTab = () => {
     //console.log(JSON.stringify(interfaceSettings.current, null, 2))
     return (
         <div>
-            <div id="interface" style="max-height: calc(100vh - 170px); overflow-y: scroll;">
+            <div id="interface" style="max-height: calc(100dvh - 170px); overflow-y: scroll;">
                 <input
                     ref={inputFile}
                     type="file"

--- a/src/targets/CNC/FluidNC/preferences.json
+++ b/src/targets/CNC/FluidNC/preferences.json
@@ -488,6 +488,7 @@
                             { "value": "0.1", "label": "0.1" },
                             { "value": "1", "label": "1" },
                             { "value": "10", "label": "10" },
+                            { "value": "50", "label": "50" },
                             { "value": "100", "label": "100" }
                         ]
                     }

--- a/src/targets/CNC/FluidNC/preferences.json
+++ b/src/targets/CNC/FluidNC/preferences.json
@@ -475,6 +475,25 @@
                 ]
             },
             {
+                "id": "jogdistance",
+                "type": "group",
+                "label": "CN18",
+                "value": [
+                    {
+                        "id": "jogdistancedefault",
+                        "type": "select",
+                        "label": " ",
+                        "value": "100",
+                        "options": [
+                            { "value": "0.1", "label": "0.1" },
+                            { "value": "1", "label": "1" },
+                            { "value": "10", "label": "10" },
+                            { "value": "100", "label": "100" }
+                        ]
+                    }
+                ]
+            },
+            {
                 "id": "keymap",
                 "sorted": false,
                 "fixed": true,

--- a/src/targets/CNC/style/_index.scss
+++ b/src/targets/CNC/style/_index.scss
@@ -49,7 +49,7 @@
 }
 
 .states-buttons-container {
-    width: 100%;
+    width: 95%;
     align-items: center;
     display: flex;
     padding: 0.5rem;


### PR DESCRIPTION
This is a collection of updates including the following:

# Extension Panel Positioning and Sizing
There was a previous update to how extensions were handled to prevent them from reloading when changing tabs involving absolute positioning.  However, this had a side effect where depending on panel positioning, if a panel changed size, it would result in extension panels being cut off.  This was resolved using a ResizeObserver on the panels so when they changed size, the extension panels would have their positions updated as well.

Another previous update (#3) made a change to allow the Jog panel to display larger to prevent scrolling when using extra axes.  For extension panels to work, this needed them to use that full size.  This was updated so that an extension panel (and other panels) will only use that full height if necessary to line up horizontally with other panels.

An issue was also resolved where extension panels were not using the full available width.

![image](https://github.com/user-attachments/assets/6e5d7a19-5e40-41ba-b350-b35e4184a2f4)

# Unnecessary Horizontal Scrollbars
Changes were made to the Information Page and Status dashboard panels to prevent unnecessary horizontal scrollbars.

# Panel Shrinking
The dashboard panel formatting was updated to allow the panels to shrink.  This is particularly useful on mobile devices.  The Terminal panel is given a minimum height of 300px to prevent it from shrinking too far.

![image](https://github.com/user-attachments/assets/61156ac4-423a-4160-883d-d009720668c4)

# Footer Cutoff
At least on Google Chrome on Android devices, the bottom of the page is cutoff.  On the Settings tab, this prevented being able to use the bottom buttons.  This behavior is described here:
https://developer.chrome.com/blog/url-bar-resizing

This was resolved by basing the height on 100dvh (dynamic viewport height) instead of 100vh.  This results in the height reflecting what is actually visible, whether or not the URL address bar is displayed.

# Macro Panel Formatting
The buttons on the macro panel were not well formatted and the spacing could make it difficult to select the appropriate macro depending on sizing.  The formatting was updated to display in a grid with additional margin.

Before:
![image](https://github.com/user-attachments/assets/5607aca9-eede-407d-8d8c-3d98af0c67bb)

After:
![image](https://github.com/user-attachments/assets/fe5f7dfb-5e84-4104-b92c-c9f5876ba234)

# Jog Panel Default Distance Configuration
There were a couple of requests to change the default jog distance of 100.  If accidentally jogging, that distance can be problematic.  It still defaults to 100, but allows for changing to the other selectable values.

![image](https://github.com/user-attachments/assets/d51d5305-6831-47c5-a90b-13ed87165637)

![image](https://github.com/user-attachments/assets/6f027db1-1b24-4cb4-bf88-14d717cf90c5)

