### PR TITLE
Add silent (background) URL address macro type

### DIFF
--- a/languages/lang-de.json
+++ b/languages/lang-de.json
@@ -227,6 +227,7 @@
   "S223": "Standard-Dateisystem",
   "S224": "Dateien sortieren",
   "S225": "Dokumentation",
+  "S226": "URL-Adresse (im Hintergrund)",
   "btn+X": "X+",
   "btn-X": "X-",
   "btnHX": "X-Achse referenzieren",

--- a/languages/master_translations.json
+++ b/languages/master_translations.json
@@ -227,6 +227,7 @@
  "S223": "Default filesystem",
  "S224": "Sort files",
  "S225": "Documentation",
+ "S226": "URL address (silent)",
  "btn+X": "X+",
  "btn-X": "X-",
  "btnHX": "Home X",

--- a/src/components/Panels/Macros.tsx
+++ b/src/components/Panels/Macros.tsx
@@ -36,7 +36,7 @@ import type { TargetContextFn } from "../../targets/types"
  *
  */
 // Types matching MacrosTab.tsx
-type MacroType = "FS" | "SD" | "URI" | "CMD"
+type MacroType = "FS" | "SD" | "URI" | "URI_SILENT" | "CMD"
 
 interface MacroValue {
     name: string
@@ -92,6 +92,27 @@ const MacrosPanel: FunctionalComponent = () => {
         acc.push(item)
         return acc
     }, [])
+    // Fire a GET request in the background without opening/navigating a tab
+    // - used for URI_SILENT and for the legacy [SILENT] prefix on URI
+    const silentFetch = (uri: string): void => {
+        const myInit: RequestInit = {
+            method: "GET",
+            mode: "cors",
+            cache: "default",
+        }
+        fetch(uri, myInit)
+            .then((response) => {
+                if (response.ok) {
+                    console.log("Request succeeded")
+                } else {
+                    console.log("Request failed")
+                }
+            })
+            .catch((error) => {
+                console.log(`Request failed: ${  error.message}`)
+            })
+    }
+
     const processMacro = (action: string, type: MacroType): void => {
         switch (type) {
             case "FS":
@@ -107,7 +128,7 @@ const MacrosPanel: FunctionalComponent = () => {
                     "",
                     action
                 )
-            
+
                 const cmds = response.cmd.split("\n")
                 cmds.forEach((cmd: string) => {
                     sendCommand(cmd)
@@ -119,30 +140,17 @@ const MacrosPanel: FunctionalComponent = () => {
             //TFT SD ? same as above
             //TFT USB ? same as above
             case "URI": {
-                //open new page or silent command
+                //open new page, or silent command via the legacy [SILENT] prefix
                 if (action.trim().startsWith("[SILENT]")) {
-                    const uri = action.trim().replace("[SILENT]", "")
-                    var myInit: RequestInit = {
-                        method: "GET",
-                        mode: "cors",
-                        cache: "default",
-                    }
-                    fetch(uri, myInit)
-                        .then((response) => {
-                            if (response.ok) {
-                                console.log("Request succeeded")
-                            } else {
-                                console.log("Request failed")
-                            }
-                        })
-                        .catch((error) => {
-                            console.log(`Request failed: ${  error.message}`)
-                        })
+                    silentFetch(action.trim().replace("[SILENT]", ""))
                 } else {
                     window.open(action)
                 }
                 break
             }
+            case "URI_SILENT":
+                silentFetch(action.trim())
+                break
             case "CMD": {
                 //split by ; and show in terminal
                 const commandsList = action.trim().split(";")

--- a/src/components/Panels/Macros.tsx
+++ b/src/components/Panels/Macros.tsx
@@ -93,20 +93,27 @@ const MacrosPanel: FunctionalComponent = () => {
         return acc
     }, [])
     // Fire a GET request in the background without opening/navigating a tab
-    // - used for URI_SILENT and for the legacy [SILENT] prefix on URI
+    // - used for URI_SILENT and for the legacy [SILENT] prefix on URI.
+    // mode: "no-cors" (rather than "cors") because the typical target here
+    // is a LAN device (e.g. a Tasmota smart plug) with no CORS headers -
+    // under "cors" the browser rejects reading such a response and the
+    // promise rejects into .catch(), logging a misleading "failed" even
+    // though the GET reached the device and ran (CORS only blocks reading
+    // the response, not sending the request). Under "no-cors" the response
+    // is opaque: response.ok/.status are always false/0 regardless of what
+    // actually happened at the target, so .then() can only honestly report
+    // that the request was sent, not that it succeeded at the HTTP level.
+    // .catch() still means something real under no-cors - it only fires for
+    // network-level failures (DNS, connection refused, timeout), not CORS.
     const silentFetch = (uri: string): void => {
         const myInit: RequestInit = {
             method: "GET",
-            mode: "cors",
+            mode: "no-cors",
             cache: "default",
         }
         fetch(uri, myInit)
-            .then((response) => {
-                if (response.ok) {
-                    console.log("Request succeeded")
-                } else {
-                    console.log("Request failed")
-                }
+            .then(() => {
+                console.log("Request sent")
             })
             .catch((error) => {
                 console.log(`Request failed: ${  error.message}`)

--- a/src/components/Panels/Macros.tsx
+++ b/src/components/Panels/Macros.tsx
@@ -142,9 +142,9 @@ const MacrosPanel: FunctionalComponent = () => {
             case "URI": {
                 //open new page, or silent command via the legacy [SILENT] prefix
                 if (action.trim().startsWith("[SILENT]")) {
-                    silentFetch(action.trim().replace("[SILENT]", ""))
+                    silentFetch(action.trim().replace("[SILENT]", "").trim())
                 } else {
-                    window.open(action)
+                    window.open(action, "_blank", "noopener,noreferrer")
                 }
                 break
             }

--- a/src/tabs/interface/importHelper.ts
+++ b/src/tabs/interface/importHelper.ts
@@ -172,6 +172,7 @@ function formatItem(itemData: RawItemData, index: number = -1, origineId: string
                                 ],
                             },
                             { label: "S139", value: "URI" },
+                            { label: "S226", value: "URI_SILENT" },
                             { label: "S140", value: "CMD" },
                         ]
                     } else {

--- a/src/targets/translations/en.json
+++ b/src/targets/translations/en.json
@@ -227,6 +227,7 @@
     "S223": "Default filesystem",
     "S224": "Sort files",
     "S225": "Documentation",
+    "S226": "URL address (silent)",
     "btn+X": "X+",
     "btn-X": "X-",
     "btnHX": "Home X",


### PR DESCRIPTION
### Problem

The existing "URL address" macro type opens the target URL with `window.open()`. That's disruptive for macros that just poke another device's HTTP API and don't need any page shown at all - it steals focus and leaves a stray tab open every time you click the macro button.

A common use case: a WiFi smart plug (e.g. Tasmota) controlling power to the machine/a dust extractor/etc., toggled via its HTTP API, e.g.:

```
http://192.168.30.4/cm?cmnd=Power%20TOGGLE
```

There's already an undocumented way to do this - the URI type checks for a `[SILENT]` prefix on the action and does a `fetch()` instead of `window.open()` if present - but nothing in the UI surfaces that convention, so it's effectively undiscoverable unless you read the source.

### Fix

Added **"URL address (silent)"** as its own macro type in the dropdown, so it's discoverable without needing to know about the prefix trick. Example action for a Tasmota plug: `http://192.168.30.4/cm?cmnd=Power%20TOGGLE` - type "URL address (silent)", no prefix needed.

Extracted the existing fetch/then/catch into a small `silentFetch()` helper shared between the new type and the legacy `[SILENT]` prefix on the URI type, which keeps working as-is for anyone already relying on it.

### Screenshots

![Macro settings - type dropdown](https://raw.githubusercontent.com/WaldemarFech/ESP3D-WEBUI/pr-assets/pr-assets/macros-settings.png)

![Dashboard - macro toggling a Tasmota smart plug in the background, no tab opened](https://raw.githubusercontent.com/WaldemarFech/ESP3D-WEBUI/pr-assets/pr-assets/macros-dashboard.png)

The second screenshot shows the macro ("Vac") toggling a Tasmota-controlled outlet - the device's own page (right, opened separately for comparison) confirms it went `ON`, while the FluidNC dashboard (left) never navigated away or opened a tab.

### Notes

Tested against a real Jackpot v1 board (ESP32, FluidNC v4.0.3, WebUI 3.0.10.fluidnc).