### PR TITLE
Stop preferences.json being lost from Flash, and fix the upload progress bar

### DIFF
--- a/src/areas/index.tsx
+++ b/src/areas/index.tsx
@@ -730,7 +730,7 @@ const ContentContainer: FunctionalComponent = () => {
                     formDataExtensions.append("creatPath", "true")
                     formDataExtensions.append(
                         `${preferencesFileName  }S`,
-                        preferencestosave.length.toString()
+                        blob.size.toString()
                     )
                     formDataExtensions.append(
                         "myfiles",

--- a/src/contexts/HttpQueueContext.tsx
+++ b/src/contexts/HttpQueueContext.tsx
@@ -39,6 +39,7 @@ interface HttpQueueContextValue {
     removeRequests: (requestIds: string | string[]) => void
     getCurrentRequest: () => any
     removeAllRequests: () => void
+    abortOnControllerError: () => void
     processRequests: () => void
 }
 
@@ -64,6 +65,7 @@ const useHttpQueueContext = (): HttpQueueContextValue => {
             removeRequests: () => {},
             getCurrentRequest: () => null,
             removeAllRequests: () => {},
+            abortOnControllerError: () => {},
             processRequests: () => {}
         }
     }
@@ -116,6 +118,25 @@ const HttpQueueContextProvider: FunctionalComponent<HttpQueueContextProviderProp
         if (currentRequest.current) currentRequest.current.abort()
         requestQueue.current = []
         currentRequest.current = null
+    }
+
+    //A file upload posts its content as a FormData body
+    const isFileUpload = (request?: HttpRequest) =>
+        typeof FormData != "undefined" && request?.params?.body instanceof FormData
+
+    /*
+     * Abort what an error reported by the controller invalidated.
+     *
+     * An in-flight ESP command will never get its answer once the controller
+     * errors, so it has to be dropped. A file upload has nothing to do with
+     * what the controller is running: aborting it mid-body leaves the firmware
+     * with a partially written file, which it then removes. That is how
+     * preferences.json disappears from Flash when a macro is saved while a job
+     * is running and the job reports an error.
+     */
+    const abortOnControllerError = () => {
+        if (isFileUpload(requestQueue.current[0])) return
+        removeAllRequests()
     }
 
     //Process requests from queue
@@ -184,6 +205,7 @@ const HttpQueueContextProvider: FunctionalComponent<HttpQueueContextProviderProp
                 removeRequests,
                 getCurrentRequest,
                 removeAllRequests,
+                abortOnControllerError,
                 processRequests,
             }}
         >

--- a/src/contexts/ModalsContext.tsx
+++ b/src/contexts/ModalsContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, FunctionalComponent, ComponentChildren } from "preact"
-import { useContext, useState, useCallback, useMemo } from "preact/hooks"
+import { useContext, useState, useRef, useCallback, useMemo } from "preact/hooks"
 import { generateUID, disableUI } from "../components/Helpers"
 
 // Type definitions
@@ -33,32 +33,46 @@ const useModalsContext = () => {
 
 const ModalsContextProvider: FunctionalComponent<ModalsContextProviderProps> = ({ children }) => {
     const [modals, setModal] = useState<Modal[]>([])
+    //Callbacks stored in a modal (or captured by an async request) outlive the
+    //render they were created in, so the modal list must be read from a ref and
+    //not from the state snapshot that closure captured, otherwise looking a
+    //modal up by id returns -1 and it can never be removed.
+    const modalsRef = useRef<Modal[]>(modals)
+
+    const applyModals = useCallback((newModalList: Modal[]) => {
+        modalsRef.current = newModalList
+        setModal(newModalList)
+    }, [])
 
     const addModal = useCallback(
-        (newModal: Modal) =>
-            setModal((prev) => [...prev, { ...newModal, id: newModal.id ? newModal.id : generateUID() }]),
-        []
+        (newModal: Modal) => {
+            applyModals([
+                ...modalsRef.current,
+                { ...newModal, id: newModal.id ? newModal.id : generateUID() },
+            ])
+        },
+        [applyModals]
     )
 
-    const getModalIndex = useCallback(
-        (id: string): number => {
-            return modals.findIndex((element) => element.id == id)
-        },
-        [modals]
-    )
+    const getModalIndex = useCallback((id: string): number => {
+        return modalsRef.current.findIndex((element) => element.id == id)
+    }, [])
 
     const removeModal = useCallback(
         (modalIndex: number) => {
-            const newModalList = modals.filter((modal, index) => index !== modalIndex)
-            setModal(newModalList)
+            //nothing to remove, do not touch the list
+            if (modalIndex < 0 || modalIndex >= modalsRef.current.length) return
+            const newModalList = modalsRef.current.filter((modal, index) => index !== modalIndex)
+            applyModals(newModalList)
             if (newModalList.length == 0) disableUI(false)
         },
-        [modals]
+        [applyModals]
     )
 
     const clearModals = useCallback(() => {
-        setModal([])
-    }, [])
+        applyModals([])
+        disableUI(false)
+    }, [applyModals])
 
     const store: ModalsContextValue = useMemo(
         () => ({

--- a/src/hooks/useFilesManager.ts
+++ b/src/hooks/useFilesManager.ts
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 import { h } from "preact"
-import { useEffect, useState } from "preact/hooks"
+import { useEffect, useRef, useState } from "preact/hooks"
 import { T } from "../components/Translations"
 import { useHttpFn } from "./useHttpQueue"
 import type { UseHttpFn } from "./useHttpQueue"
@@ -112,8 +112,13 @@ export function useFilesManager(): [FilesManagerState, FilesManagerActions] {
         }
     }
 
-    const progressBar: { update?: (n: number) => void } = {}
-    const uploadStatusLabel: { element?: HTMLElement | null } = {}
+    //kept in refs so the object identity survives re-renders: <Progress /> binds
+    //its update() on mount and the in-flight request callbacks must keep talking
+    //to that very same object
+    const progressBarRef = useRef<{ update?: (n: number) => void }>({})
+    const progressBar = progressBarRef.current
+    const uploadStatusLabelRef = useRef<{ element?: HTMLElement | null }>({})
+    const uploadStatusLabel = uploadStatusLabelRef.current
 
     const onCancel = (): void => {
         useUiContextFn.haptic()
@@ -258,14 +263,17 @@ export function useFilesManager(): [FilesManagerState, FilesManagerActions] {
                     },
                     text: T("S28"),
                 },
-                content: totalFiles > 1
-                    ? h("label", {
-                          ref: (el: HTMLElement) => {
-                              uploadStatusLabel.element = el
-                          },
-                          style: "display:block;margin-bottom:0.5rem;text-align:center;",
-                      }, `1 / ${totalFiles}: ${fileEntries[0].fileName}`)
-                    : null,
+                content: h("div", {}, [
+                    totalFiles > 1
+                        ? h("label", {
+                              ref: (el: HTMLElement) => {
+                                  uploadStatusLabel.element = el
+                              },
+                              style: "display:block;margin-bottom:0.5rem;text-align:center;",
+                          }, `1 / ${totalFiles}: ${fileEntries[0].fileName}`)
+                        : null,
+                    h(Progress, { progressBar, max: 100 }),
+                ]),
             })
 
             const pathPrefix =

--- a/src/hooks/useWebSocketService.ts
+++ b/src/hooks/useWebSocketService.ts
@@ -16,7 +16,7 @@ export function useWebSocketService() : WebSocketService {
     const { toasts } = useToastsContext();
     const { modals } = useModalsContext();
     const { processData } = useTargetContext();
-    const { removeAllRequests } = useHttpQueueContext();
+    const { abortOnControllerError } = useHttpQueueContext();
     const { connectionSettings, activity } = useSettingsContext();
 
     const serviceRef = useRef<WebSocketService | undefined>();
@@ -82,9 +82,10 @@ export function useWebSocketService() : WebSocketService {
                 dialogs.setShowKeepConnected(false);
             });
 
-            // Set up error handler to abort HTTP requests on controller errors
+            // Set up error handler to abort HTTP requests on controller errors,
+            // except a file upload, which the controller error says nothing about
             webSocketServiceInstance.setErrorHandler((errorCode, errorMessage) => {
-                removeAllRequests();
+                abortOnControllerError();
             });
         }
 
@@ -92,7 +93,7 @@ export function useWebSocketService() : WebSocketService {
         return () => {
             // Don't disconnect on unmount - service should persist
         };
-    }, [connection, dialogs, toasts, modals, processData, removeAllRequests, connectionSettings, activity, uisettings]);
+    }, [connection, dialogs, toasts, modals, processData, abortOnControllerError, connectionSettings, activity, uisettings]);
 
     // Return the service instance (will be undefined if not yet initialized)
     return serviceRef.current!;

--- a/src/tabs/interface/index.tsx
+++ b/src/tabs/interface/index.tsx
@@ -36,6 +36,7 @@ import { RefreshCcw, Save, ExternalLink, Flag, Download } from "preact-feather"
 import { Field, FieldGroup } from "../../components/Controls"
 import { exportPreferences, exportPreferencesSection, ExportPreferences, InterfaceSettingsData } from "./exportHelper"
 import { importPreferencesSection, formatPreferences, ImportPreferencesResult } from "./importHelper"
+import { useTargetContext } from "../../targets"
 
 // Option for select fields
 interface SelectOption {
@@ -74,6 +75,28 @@ interface ValidationResult {
     valid: boolean;
     modified: boolean;
 }
+
+/*
+ * States in which writing to the ESP filesystem is unsafe.
+ *
+ * While a job streams from Flash the firmware cannot service a second write to
+ * the same filesystem: it answers "Upload failed - file write failed" and then
+ * "Upload aborted - discarding partial file". By then preferences.json has
+ * already been created for the upload, so discarding the partial file takes the
+ * previous contents with it and nothing is left on Flash.
+ */
+const machineBusyStates = ["Run", "Hold", "Jog", "Home", "Door"]
+
+/**
+ * Tell whether the controller is busy enough that a file write would fail.
+ *
+ * @param status - Controller status from the target context
+ * @param streamStatus - Streaming status from the target context
+ * @returns True when preferences.json must not be written
+ */
+const isMachineBusy = (status: any, streamStatus: any): boolean =>
+    machineBusyStates.includes(status?.state) ||
+    streamStatus?.status == "processing"
 
 const isDependenciesMet = (depend: any): boolean => {
     const { interfaceSettings, connectionSettings } = useSettingsContext()
@@ -330,6 +353,10 @@ const generateValidationGlobal = (
 const InterfaceTab = () => {
     const { toasts } = useToastsContext()
     const { createNewRequest, abortRequest } = useHttpQueue()
+    const { status, streamStatus } = useTargetContext() as unknown as {
+        status: any
+        streamStatus: any
+    }
     const { getInterfaceSettings } = useSettings()
     const { interfaceSettings, connectionSettings } = useSettingsContext()
     const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -413,6 +440,13 @@ const InterfaceTab = () => {
     }
 
     const SaveSettings = () => {
+        //Writing to Flash while the controller streams a job from it makes the
+        //firmware discard the partially written file, losing preferences.json
+        //altogether. Refuse the save rather than destroy the stored settings.
+        if (isMachineBusy(status, streamStatus)) {
+            toasts.addToast({ content: T("S233"), type: "error" })
+            return
+        }
         const settings_to_save: ExportPreferences = exportPreferences(
             interfaceSettings.current as InterfaceSettingsData,
             false

--- a/src/tabs/interface/index.tsx
+++ b/src/tabs/interface/index.tsx
@@ -428,8 +428,10 @@ const InterfaceTab = () => {
         const file = new File([blob], preferencesFileName)
         formData.append("path", useSettingsContextFn.getValue("HostUploadPath"))
         formData.append("creatPath", "true")
+        //append file size first so the firmware can check the upload is complete
+        //use the blob byte length, not the string length, as they differ for non ASCII content
+        formData.append(`${preferencesFileName  }S`, String(blob.size))
         formData.append("myfiles", file, preferencesFileName)
-        formData.append(`${preferencesFileName  }S`, String(preferencestosave.length))
         setIsLoading(true)
         createNewRequest(
             espHttpURL(useSettingsContextFn.getValue("HostTarget")),

--- a/src/targets/translations/en.json
+++ b/src/targets/translations/en.json
@@ -227,6 +227,7 @@
     "S223": "Default filesystem",
     "S224": "Sort files",
     "S225": "Documentation",
+    "S233": "Cannot save while a job is running - stop the job first",
     "btn+X": "X+",
     "btn-X": "X-",
     "btnHX": "Home X",


### PR DESCRIPTION
Three fixes for losing `preferences.json` off the ESP filesystem, and for the upload progress dialog.

## preferences.json disappearing from Flash

Reported symptom: saving a macro or an interface setting while a job is running leaves the board with no `preferences.json` at all. Two independent causes.

**A controller error aborted the upload.** Every `ERROR:` line the controller sends over the WebSocket reaches the handler in `useWebSocketService.ts`, which called `removeAllRequests()` — aborting whatever HTTP request happened to be in flight, regardless of what it was. A running job reports errors routinely, so an error arriving during the `preferences.json` upload aborted the POST mid-body, and the firmware discarded the partially written file.

Aborting is still right for an ESP command, which will never get its answer once the controller errors. A file upload has nothing to do with what the controller is running, so `abortOnControllerError()` now leaves uploads alone and behaves exactly as before for everything else.

**Saving while a job streamed from Flash.** The firmware cannot service a write to the filesystem it is streaming from:

```
[MSG:INFO: Upload failed - file write failed]
[MSG:INFO: Upload aborted - discarding partial file]
```

By the time it discards the partial file, `preferences.json` has already been created for the upload, so the previous contents go with it. The WebUI cannot make that write succeed, so it no longer tries: saving is refused while the machine is in `Run`, `Hold`, `Jog`, `Home` or `Door`, or while a stream is processing, and the stored preferences are left untouched. Adds `S233`.

**Size argument ordering.** `SaveSettings` appended the declared size *after* the file part. Every other upload in the code base appends it first — `useFilesManager.ts` even documents why (`//append file size first to check upload is complete`), and this branch's parent had it in the right order before the TypeScript conversion moved it. The firmware needs that size when the data arrives to tell a complete upload from a truncated one. Also declares it in bytes (`blob.size`) rather than UTF-16 code units (`String.length`), which differ for any non-ASCII content in preferences.

## Upload progress bar

Three separate problems: the `<Progress>` element was never rendered at all in the multi-file branch (`content` held only the label), `progressBar` was recreated on every render so `update()` bound to an object the in-flight callbacks no longer referenced, and `getModalIndex` read the state snapshot captured in its closure, returning `-1` — so the progress dialog could never be dismissed.

## Testing

`npm run type-check` and `npm run build` both pass on this branch alone. No new lint errors on any touched file. The abort guard was exercised directly against the queue code: uploads survive a controller `ERROR:`, ESP commands and file listings still abort as before. The busy-state guard was checked across `Idle`/`Alarm`/`Sleep` (save allowed) and `Run`/`Hold`/`Jog`/`Home`/`Door`/streaming (save refused).

Not verified on hardware — the firmware-side half of the first two causes is inferred from the console output above.
