### PR TITLE
Show all active coolant modes and the tool number; fix the browser tab title

### DIFF
--- a/src/areas/connection.tsx
+++ b/src/areas/connection.tsx
@@ -20,6 +20,7 @@
 import { FunctionalComponent, TargetedMouseEvent } from "preact"
 import { useRef } from "preact/hooks"
 import { useUiContext, useSettingsContext, useUiContextFn } from "../contexts"
+import { setPageTitle } from "../components/Helpers"
 import { Loading } from "../components/Controls"
 import { AppLogo } from "../targets"
 import {
@@ -77,14 +78,7 @@ const ConnectionContainer: FunctionalComponent = () => {
                 if (connection.connectionState.extraMsg)
                     contentSubtitle +=
                         `: ${  connection.connectionState.extraMsg}`
-                document.title =
-                    `${connectionSettings.current &&
-                    connectionSettings.current.HostName
-                        ? connectionSettings.current.HostName
-                        : "ESP3D" 
-                    }(${ 
-                    T("S22") 
-                    })`
+                setPageTitle(connectionSettings.current, T("S22"))
                 contentAction = (
                     <button class="btn" onClick={onclick}>
                         {T("S8")}
@@ -102,14 +96,7 @@ const ConnectionContainer: FunctionalComponent = () => {
                     connection.connectionState.page == "connectionlost"
                         ? T("S10")
                         : T("S173") //"Connection with board is lost"
-                document.title =
-                    `${connectionSettings.current &&
-                    connectionSettings.current.HostName
-                        ? connectionSettings.current.HostName
-                        : "ESP3D" 
-                    }(${ 
-                    T("S9") 
-                    })`
+                setPageTitle(connectionSettings.current, T("S9"))
                 contentAction = (
                     <button class="btn" onClick={onclick}>
                         {T("S11")}
@@ -122,14 +109,7 @@ const ConnectionContainer: FunctionalComponent = () => {
                 contentTitle = T("S9")
                 contentIcon = <Slash style={{ width: "50px", height: "50px" }} />
                 contentSubtitle = T("S3")
-                document.title =
-                    `${connectionSettings.current &&
-                    connectionSettings.current.HostName
-                        ? connectionSettings.current.HostName
-                        : "ESP3D" 
-                    }(${ 
-                    T("S9") 
-                    })`
+                setPageTitle(connectionSettings.current, T("S9"))
                 contentAction = (
                     <button class="btn" onClick={onclick}>
                         {T("S11")}
@@ -140,14 +120,7 @@ const ConnectionContainer: FunctionalComponent = () => {
             case "restart":
                 intervalTimer = restartdelay
                 setTimeout(refreshTimer, 1000)
-                document.title =
-                    `${connectionSettings.current &&
-                    connectionSettings.current.HostName
-                        ? connectionSettings.current.HostName
-                        : "ESP3D" 
-                    }(${ 
-                    T("S35") 
-                    })`
+                setPageTitle(connectionSettings.current, T("S35"))
                 contentTitle = T("S35") //"restarting";
                 contentIcon = (
                     <div class="d-inline-block content-icon">
@@ -172,14 +145,7 @@ const ConnectionContainer: FunctionalComponent = () => {
                         updating: false,
                     })
                 } else {
-                    document.title =
-                        `${connectionSettings.current &&
-                        connectionSettings.current.HostName
-                            ? connectionSettings.current.HostName
-                            : "ESP3D" 
-                        }(${ 
-                        T("S2") 
-                        })`
+                    setPageTitle(connectionSettings.current, T("S2"))
                     contentTitle = T("S2") //"Connecting";
                 }
                 contentIcon = (

--- a/src/components/Helpers/index.ts
+++ b/src/components/Helpers/index.ts
@@ -50,6 +50,7 @@ import {
 import { dispatchToExtensions, isFullscreenActive, isFullscreenSupported, getFullscreenElement, invalidateIframeCache } from "./html"
 import { sortedFilesList, filterResultFiles } from "./filters"
 import { useStoredState } from "./storedState"
+import { getHostName, buildPageTitle, setPageTitle } from "./pageTitle"
 
 export {
     beautifyJSONString,
@@ -87,6 +88,9 @@ export {
     isFloat,
     BitsArray,
     useStoredState,
+    getHostName,
+    buildPageTitle,
+    setPageTitle,
 }
 
 // Re-export types

--- a/src/components/Helpers/pageTitle.ts
+++ b/src/components/Helpers/pageTitle.ts
@@ -1,0 +1,74 @@
+/*
+ pageTitle.ts - ESP3D WebUI helper file
+
+ Copyright (c) 2021 Luc LEBOSSE. All rights reserved.
+
+ This code is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ This code is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public
+ License along with This code; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+const DEFAULT_HOST_NAME = "ESP3D"
+
+/**
+ * Resolve the board name used in the browser tab.
+ *
+ * The name comes straight from the ESP800 payload, which on some firmwares
+ * carries the literal string "undefined" rather than omitting the entry. A
+ * plain `||` lets that through and the tab ends up titled "undefined", so the
+ * string is rejected here alongside a missing or blank value.
+ *
+ * @param connectionSettings - Current connection settings, if already fetched
+ * @returns The board name, or `ESP3D` when there is nothing usable
+ */
+const getHostName = (connectionSettings?: { HostName?: string } | null): string => {
+    const name = connectionSettings?.HostName
+    if (typeof name != "string") return DEFAULT_HOST_NAME
+    const trimmed = name.trim()
+    if (trimmed.length == 0 || trimmed == "undefined" || trimmed == "null")
+        return DEFAULT_HOST_NAME
+    return trimmed
+}
+
+/**
+ * Build the browser tab title.
+ *
+ * @param connectionSettings - Current connection settings, if already fetched
+ * @param suffix - Connection state shown in parentheses, e.g. "connecting"
+ * @param prefix - Job progress shown ahead of the name, e.g. "42% Run"
+ * @returns The title to assign to `document.title`
+ */
+const buildPageTitle = (
+    connectionSettings?: { HostName?: string } | null,
+    suffix?: string,
+    prefix?: string
+): string => {
+    const name = getHostName(connectionSettings)
+    const base = suffix ? `${name}(${suffix})` : name
+    return prefix ? `${prefix} - ${base}` : base
+}
+
+/**
+ * Set the browser tab title.
+ *
+ * @param connectionSettings - Current connection settings, if already fetched
+ * @param suffix - Connection state shown in parentheses
+ * @param prefix - Job progress shown ahead of the name
+ */
+const setPageTitle = (
+    connectionSettings?: { HostName?: string } | null,
+    suffix?: string,
+    prefix?: string
+): void => {
+    document.title = buildPageTitle(connectionSettings, suffix, prefix)
+}
+
+export { getHostName, buildPageTitle, setPageTitle, DEFAULT_HOST_NAME }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -20,6 +20,7 @@ import { h } from "preact"
 import {
     espHttpURL,
     isLimitedEnvironment,
+    setPageTitle,
 } from "../components/Helpers"
 import { useHttpQueue, useTargetCommands } from "../hooks/"
 import {
@@ -179,7 +180,7 @@ const useSettings = (): UseSettingsReturn => {
                 }
                 processData("core", "ESP800", true)
                 //console.log(connectionSettings.current)
-                document.title = connectionSettings.current.HostName || "ESP3D"
+                setPageTitle(connectionSettings.current)
                 if (
                     !connectionSettings.current.HostPath ||
                     !connectionSettings.current.HostPath.length
@@ -283,7 +284,7 @@ const useSettings = (): UseSettingsReturn => {
                 connected: true,
                 page: "connecting",
             })
-            document.title = connectionSettings.current.HostName || "ESP3D"
+            setPageTitle(connectionSettings.current)
             setTimeout(initPolling, 2000)
             console.log("Ui is ready")
             ui.setReady(true)

--- a/src/targets/CNC/FluidNC/TargetContext.tsx
+++ b/src/targets/CNC/FluidNC/TargetContext.tsx
@@ -17,10 +17,11 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 import { createContext, VNode } from "preact"
-import { useRef, useContext, useState, useMemo } from "preact/hooks"
+import { useRef, useContext, useState, useMemo, useEffect } from "preact/hooks"
 import {
     dispatchToExtensions,
     beautifyJSONString,
+    setPageTitle,
 } from "../../../components/Helpers"
 import { useDatasContext, useSettingsContextFn } from "../../../contexts"
 import { processor } from "./processor"
@@ -81,7 +82,7 @@ const TargetContextProvider = ({ children }: TargetContextProviderProps) => {
     const [overrides, setOverrides] = useState({})
     const [pinsStates, setPinStates] = useState(lastPins)
     const [states, setStates] = useState({})
-    const [streamStatus, setStreamStatus] = useState({})
+    const [streamStatus, setStreamStatus] = useState<Record<string, any>>({})
     const [message, setMessage] = useState<string | undefined>()
     const [alarmCode, setAlarmCode] = useState(0)
     const [errorCode, setErrorCode] = useState(0)
@@ -388,6 +389,30 @@ const TargetContextProvider = ({ children }: TargetContextProviderProps) => {
             dispatchToExtensions(type, data)
         }
     }
+
+    /*
+     * Show job progress in the browser tab, the way a print server does, so a
+     * backgrounded tab still tells how far along the job is. Reverts to the
+     * plain board name once nothing is streaming; the connection screens set
+     * their own title and are not running a job, so they do not conflict.
+     */
+    useEffect(() => {
+        const total = Number(streamStatus.total)
+        const processed = Number(streamStatus.processed)
+        if (!streamStatus.status) {
+            setPageTitle({ HostName: useSettingsContextFn.getValue("HostName") })
+            return
+        }
+        const percent =
+            Number.isFinite(total) && total > 0 && Number.isFinite(processed)
+                ? `${Math.min(100, Math.round((processed / total) * 100))}% `
+                : ""
+        setPageTitle(
+            { HostName: useSettingsContextFn.getValue("HostName") },
+            undefined,
+            `${percent}${status.state || streamStatus.status}`
+        )
+    }, [streamStatus, status.state])
 
     useTargetContextFn.processData = processData
 

--- a/src/targets/CNC/FluidNC/filters.ts
+++ b/src/targets/CNC/FluidNC/filters.ts
@@ -239,18 +239,33 @@ const getStates = (str: string): Record<string, any> => {
                 cur.startsWith("S") ||
                 cur.startsWith("T")
             ) {
+                //"T" matches the { id: "T", pre: "T" } entry of
+                //gcode_parser_modes, which is how the tool number reaches the
+                //Modes section of the status panel. feed rate and spindle speed
+                //keep their own keys, they are read by the spindle panel.
                 acc[
                     cur[0] == "F"
                         ? "feed_rate"
                         : cur[0] == "T"
-                          ? "active_tool"
+                          ? "T"
                           : "spindle_speed"
                 ] = { value: parseFloat(cur.substring(1)) }
             } else {
                 gcode_parser_modes.forEach((mode) => {
                     const el = cur.split(":")[0]
                     if ('values' in mode && mode.values && mode.values.includes(el)) {
-                        acc[mode.id] = { value: cur }
+                        //A group can report several values at once: the
+                        //controller lists M7 and M8 together when both mist and
+                        //flood are running. Keep every one of them, the status
+                        //panel already renders an array as one button per value.
+                        const previous = acc[mode.id]
+                        if (typeof previous == "undefined") {
+                            acc[mode.id] = { value: cur }
+                        } else {
+                            acc[mode.id] = Array.isArray(previous)
+                                ? [...previous, { value: cur }]
+                                : [previous, { value: cur }]
+                        }
                     }
                 })
             }


### PR DESCRIPTION
Fixes #1 and #11. Both turned out to be small parser/helper bugs rather than missing features — in the status panel case the UI already supported what was asked for.

## Status panel: every active coolant mode, and the tool number (#1)

**M7 and M8 together.** `getStates()` stored one value per mode group, so with the controller reporting `M7 M8` for mist and flood at once, the second overwrote the first. Values of a group now accumulate into an array — `StatusCNC` already branches on `Array.isArray` and renders one button per entry, so nothing in the UI changed.

**Tool number.** The parser stored it as `active_tool`, which nothing in the code base reads, while `gcode_parser_modes` declares it as `{ id: "T", pre: "T", label: "CN58" }` and the panel looks it up under `"T"`. Storing it under `"T"` makes the existing descriptor and its "Active tool" label work. Feed rate and spindle speed keep their own keys — the spindle panel reads those.

Verified against real `[GC:]` lines:

| reported | `coolant_mode` | `T` |
| --- | --- | --- |
| `M5 M9 T0` | `M9` | `0` |
| `M5 M7 T1` | `M7` | `1` |
| `M5 M8 T2` | `M8` | `2` |
| `M3 M7 M8 T3` | `[M7, M8]` | `3` |

Groups with a single active value still produce a plain object, so nothing else changes.

Note: `{ id: "S" }` and `{ id: "F" }` have the same mismatch — the parser writes `spindle_speed`/`feed_rate`. Left alone, since that data already appears in the spindle panel and the issue only asked for the tool number.

## Browser tab: progress instead of "undefined" (#11)

**The "undefined".** The board name comes straight from the ESP800 payload, which on some firmwares carries the literal string `"undefined"` rather than omitting the entry. `HostName || "ESP3D"` catches a missing value but passes that string straight through, so the tab ends up titled `undefined`. `getHostName()` now rejects it alongside blank and missing values.

The same title expression was copied five times in `connection.tsx` and twice more in `useSettings.ts`; all seven now go through `setPageTitle()`.

**Progress.** While a job streams, the tab shows progress and state ahead of the board name — `42% Run - fluidnc` — so a backgrounded tab still says how far along the job is, which is what the issue asked for. It reverts to the plain board name once nothing is streaming.

Verified: `"undefined"`, missing, `""`, whitespace and `"null"` all fall back to `ESP3D`; a normal name is preserved and trimmed; the connection-state suffix still renders as `fluidnc(connecting)`.

## Testing

`npm run type-check` and `npm run build` both pass on this branch alone. No new lint errors on any touched file. The parser and title helper were exercised directly, as above.

Not verified on hardware — the rendered panel was not observed, though the array branch it relies on is pre-existing code.
